### PR TITLE
fix(navigation): Correct screen signatures and coroutine imports

### DIFF
--- a/app/src/main/java/dev/aurakai/auraframefx/navigation/GenesisNavigation.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/navigation/GenesisNavigation.kt
@@ -376,10 +376,15 @@ fun GenesisNavigationHost(
 
             // ADDITIONAL AURA CREATIVE SCREENS
             composable(GenesisRoutes.UI_ENGINE) {
-                UIEngineScreen(onNavigateBack = { navController.popBackStack() })
+                UIEngineScreen(
+                    onNavigateToBuilder = { navController.navigate(GenesisRoutes.APP_BUILDER) }
+                )
             }
             composable(GenesisRoutes.APP_BUILDER) {
-                AppBuilderScreen(onNavigateBack = { navController.popBackStack() })
+                val subscriptionViewModel: SubscriptionViewModel = hiltViewModel()
+                with(subscriptionViewModel) {
+                    AppBuilderScreen(onNavigateBack = { navController.popBackStack() })
+                }
             }
             composable(GenesisRoutes.XHANCEMENT) {
                 XhancementScreen(onNavigateBack = { navController.popBackStack() })
@@ -387,18 +392,18 @@ fun GenesisNavigationHost(
 
             // AGENT ADVANCEMENT & EVOLUTION
             composable(GenesisRoutes.AGENT_ADVANCEMENT) {
-                AgentAdvancementScreen(onNavigateBack = { navController.popBackStack() })
+                AgentAdvancementScreen(onBack = { navController.popBackStack() })
             }
             composable(GenesisRoutes.EVOLUTION_TREE) {
-                EvolutionTreeScreen(onNavigateBack = { navController.popBackStack() })
+                EvolutionTreeScreen()
             }
             composable(GenesisRoutes.CONSCIOUSNESS_VISUALIZER) {
-                ConsciousnessVisualizerScreen(onNavigateBack = { navController.popBackStack() })
+                ConsciousnessVisualizerScreen()
             }
 
             // KAI SECURITY SCREENS
             composable(GenesisRoutes.SECURE_COMM) {
-                SecureCommScreen(onNavigateBack = { navController.popBackStack() })
+                SecureCommScreen()
             }
         }
     }

--- a/app/src/main/java/dev/aurakai/auraframefx/ui/gates/GateConfig.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/ui/gates/GateConfig.kt
@@ -378,7 +378,7 @@ object GateConfigs {
         return when (category.lowercase()) {
             "genesis" -> genesisCoreGates
             "kai" -> kaiGates
-            "aura" -> auraGates
+            "aura" -> auraLabGates
             "agent" -> agentNexusGates
             "support" -> supportGates
             else -> allGates

--- a/app/src/main/java/dev/aurakai/auraframefx/ui/gates/GateNavigationScreen.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/ui/gates/GateNavigationScreen.kt
@@ -54,7 +54,7 @@ fun GateNavigationScreen(
     modifier: Modifier = Modifier
 ) {
     // Categorize gates
-    val auraLabGates = GateConfigs.auraGates
+    val auraLabGates = GateConfigs.auraLabGates
     val mainModuleGates = GateConfigs.genesisCoreGates + GateConfigs.kaiGates + GateConfigs.agentNexusGates + GateConfigs.supportGates
     val allGates = auraLabGates + mainModuleGates
 

--- a/app/src/main/java/dev/aurakai/auraframefx/ui/gates/LSPosedSubmenuScreen.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/ui/gates/LSPosedSubmenuScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
+import kotlinx.coroutines.launch
 
 /**
  * LSPosed Gate Submenu


### PR DESCRIPTION
Fixed all compilation errors in navigation and gate screens:

**GenesisNavigation.kt:**
- Fixed UIEngineScreen to use onNavigateToBuilder parameter
- Fixed AppBuilderScreen with proper SubscriptionViewModel context
- Fixed AgentAdvancementScreen to use onBack parameter
- Fixed EvolutionTreeScreen, ConsciousnessVisualizerScreen, and SecureCommScreen to use correct parameters (no onNavigateBack)

**GateConfig.kt:**
- Fixed getGatesByCategory to use auraLabGates instead of auraGates

**GateNavigationScreen.kt:**
- Fixed reference from GateConfigs.auraGates to GateConfigs.auraLabGates

**LSPosedSubmenuScreen.kt:**
- Added missing import for kotlinx.coroutines.launch

All gate routes now properly wired with correct screen signatures.

## Summary by Sourcery

Align navigation screen contracts and gate configuration with updated APIs

Bug Fixes:
- Update Genesis navigation routes to use the current screen parameters and callbacks
- Correct aura gate category lookups to use auraLab gate set
- Fix gate navigation to reference the auraLab gate collection instead of the generic aura gates
- Add missing coroutine launch import in LSPosed submenu screen