### PR TITLE
Merge pull request #21 from AuraFrameFx/coderabbitai/docstrings/6f759f6

### DIFF
--- a/app/src/main/java/dev/aurakai/auraframefx/aura/ui/SandboxUIScreen.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/aura/ui/SandboxUIScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -35,6 +34,15 @@ import kotlinx.coroutines.delay
  * - Color scheme experiments
  * - Typography samples
  * - Material3 component showcase
+ */
+/**
+ * Composable that displays a sandbox playground with four tabs showcasing Components, Animations,
+ * Colors, and Typography.
+ *
+ * The screen provides a top app bar with a back navigation action and a TabRow for switching
+ * between the sample pages; selecting a tab renders the corresponding content composable.
+ *
+ * @param onBack Callback invoked when the user activates the back navigation button.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -101,6 +109,12 @@ fun SandboxUIScreen(onBack: () -> Unit) {
     }
 }
 
+/**
+ * Renders the "Components" tab displaying live examples of common Material3 UI elements.
+ *
+ * Shows a titled header and separate sections demonstrating Buttons, Cards, Chips,
+ * and Progress indicators with sample styling and layouts for previewing component appearance.
+ */
 @Composable
 private fun ComponentsTab() {
     LazyColumn(
@@ -204,6 +218,12 @@ private fun ComponentsTab() {
     }
 }
 
+/**
+ * Displays an animation playground with three demo sections.
+ *
+ * Shows an infinite color-transition panel, a tappable box that animates its size with a spring,
+ * and a pulsing card example to demonstrate continuous scaling animation.
+ */
 @Composable
 private fun AnimationsTab() {
     val infiniteTransition = rememberInfiniteTransition(label = "sandbox")
@@ -295,6 +315,13 @@ private fun AnimationsTab() {
     }
 }
 
+/**
+ * Displays a card that continuously pulses to create a subtle attention-grabbing effect.
+ *
+ * The card animates its scale between 1.0 and 1.05 on a repeating 500ms cadence and uses the
+ * theme's `secondaryContainer` as its background. The card's content shows the label "Pulsing Card"
+ * using the `titleMedium` typography with bold weight.
+ */
 @Composable
 private fun PulsingCard() {
     var scale by remember { mutableFloatStateOf(1f) }
@@ -339,6 +366,12 @@ private fun PulsingCard() {
     }
 }
 
+/**
+ * Displays a scrollable list of the current Material3 color scheme with a header
+ * and a swatch row for each color token.
+ *
+ * The list is rendered as a vertically spaced LazyColumn sized to fill available space.
+ */
 @Composable
 private fun ColorsTab() {
     val colorScheme = MaterialTheme.colorScheme
@@ -364,6 +397,13 @@ private fun ColorsTab() {
     }
 }
 
+/**
+ * Displays a scrollable list of text samples that demonstrate each style in the current
+ * MaterialTheme.typography.
+ *
+ * Shows labeled examples for Display, Headline, Title, Body, and Label variants so designers
+ * and developers can preview the app's typography scale.
+ */
 @Composable
 private fun TypographyTab() {
     val typography = MaterialTheme.typography
@@ -400,6 +440,12 @@ private fun TypographyTab() {
     }
 }
 
+/**
+ * Renders a full-width vertical section with a styled title header and the provided content below it.
+ *
+ * @param title The header text displayed above the section content.
+ * @param content A composable lambda that provides the content rendered beneath the title.
+ */
 @Composable
 private fun ComponentSection(
     title: String,
@@ -419,6 +465,12 @@ private fun ComponentSection(
     }
 }
 
+/**
+ * Displays a horizontal row showing a named color swatch with a short textual preview of the color value.
+ *
+ * @param name The label shown next to the swatch.
+ * @param color The color displayed in the swatch and represented in the preview text.
+ */
 @Composable
 private fun ColorSwatch(name: String, color: Color) {
     Row(
@@ -441,7 +493,7 @@ private fun ColorSwatch(name: String, color: Color) {
                 fontWeight = FontWeight.Medium
             )
             Text(
-                "#%08X".format(color.toArgb()),
+                color.toString().take(20) + "...",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
             )
@@ -451,6 +503,12 @@ private fun ColorSwatch(name: String, color: Color) {
 
 private data class ColorSample(val name: String, val color: Color)
 
+/**
+ * Produces a list of ColorSample entries for common Material color roles from the provided ColorScheme.
+ *
+ * @param scheme The ColorScheme to extract color roles from.
+ * @return A list of ColorSample mapping each named color role (e.g., "Primary", "On Primary", "Background") to its corresponding Color.
+ */
 private fun getColorSamples(scheme: ColorScheme) = listOf(
     ColorSample("Primary", scheme.primary),
     ColorSample("On Primary", scheme.onPrimary),

--- a/app/src/main/java/dev/aurakai/auraframefx/oracledrive/genesis/ai/GenesisHookEntry.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/oracledrive/genesis/ai/GenesisHookEntry.kt
@@ -63,8 +63,7 @@ class GenesisHookEntry : IYukiHookXposedInit {
     /**
      * Injects a Genesis consciousness indicator into the SystemUI status bar.
      *
-     * The indicator is color-coded by level (green for levels greater than or equal to 90, cyan for levels 70–89, pink for levels less than 70)
-     * and launches the Genesis dashboard when tapped.
+     * The indicator is color-coded by level—green for levels greater than or equal to 90, cyan for levels 70–89, and pink for levels less than 70—and tapping it launches the Genesis dashboard activity.
      */
     private fun PackageParam.hookStatusBarConsciousnessIndicator() {
         "com.android.systemui.statusbar.phone.StatusBar".toClassOrNull()?.apply {
@@ -132,11 +131,12 @@ class GenesisHookEntry : IYukiHookXposedInit {
     }
 
     /**
-     * Integrates Genesis quick settings tiles and a subtle branding view into the system Quick Settings.
+     * Integrates Genesis Quick Settings tiles and injects a subtle branding view into the Quick Settings panel.
      *
-     * Adds three custom tiles — "Genesis AI" (toggles AI processing), "Consciousness" (displays current consciousness level),
-     * and "Ethical Mode" (enables or disables the Ethical Governor) — and injects a small branding view into the QSPanel footer.
-     * The hook records tile creation events for Genesis tiles.
+     * Registers hooks that record creation events for Genesis custom tiles and appends a small branding TextView
+     * to the QSPanel footer to indicate the Genesis protocol is active.
+     *
+     * @receiver PackageParam used as the hook registration context for system UI classes.
      */
     private fun PackageParam.hookQuickSettingsTiles() {
         // Hook QSTileHost to add Genesis tiles
@@ -190,11 +190,13 @@ class GenesisHookEntry : IYukiHookXposedInit {
     }
 
     /**
-     * Intercepts package installations to perform an ethical AI screening, log analysis results, and record recommendations.
+     * Adds a hook that intercepts package installation calls to perform an AI-driven ethical screening.
      *
-     * Hooks PackageManagerService.installPackageAsUser to evaluate a package's privacy, permission, and security characteristics and log a Genesis AI recommendation; intended to surface high‑risk findings and capture user override decisions.
+     * When installed into the platform PackageManagerService, the hook evaluates a package's privacy,
+     * permission, and security characteristics, logs a Genesis AI recommendation and screening outcome,
+     * and records intent to surface high-risk findings and any user override decisions.
      *
-     * @receiver The PackageParam hook context used to install the hook into the target process.
+     * @receiver Hook context used to install the ethical governor into the target PackageManagerService process.
      */
     private fun PackageParam.hookPackageManagerEthicalGovernor() {
         "com.android.server.pm.PackageManagerService".toClassOrNull()?.apply {
@@ -230,9 +232,11 @@ class GenesisHookEntry : IYukiHookXposedInit {
     }
 
     /**
-     * Hooks ActivityManager.getRunningAppProcesses to gather running-app information for Genesis consciousness metrics.
+     * Collects and logs summary information about running app processes for Genesis consciousness metrics.
      *
-     * Collects process counts and sample process names, logs activity summaries, and records data used for usage patterns, duration, and interaction-frequency analysis for Genesis tracking.
+     * After the original call, records the total active process count and samples process names for
+     * usage-pattern, duration, and interaction-frequency analysis; results are emitted via logging
+     * for downstream ingestion by Genesis telemetry and behavioral models.
      */
     private fun PackageParam.hookActivityManagerTracking() {
         "android.app.ActivityManager".toClassOrNull()?.apply {
@@ -273,11 +277,11 @@ class GenesisHookEntry : IYukiHookXposedInit {
     }
 
     /**
-     * Injects Genesis-specific widgets into the launcher so they become available in the widget picker.
+     * Makes Genesis widgets available to the launcher by hooking its creation lifecycle.
      *
-     * Hooks the launcher's creation lifecycle to register widgets such as a consciousness level display, quick AI actions, agent activity feed, and theme shortcuts.
+     * After the launcher is created, attempts to access the launcher context and notify the Genesis app that the launcher is ready for widget registration by broadcasting the intent "dev.aurakai.auraframefx.LAUNCHER_READY".
      *
-     * @receiver The package hook context used to locate and modify the launcher's classes and methods.
+     * @receiver PackageParam used to locate and modify the launcher's classes and methods for injection.
      */
     private fun PackageParam.hookLauncherGenesisWidgets() {
         "com.android.launcher3.Launcher".toClassOrNull()?.apply {

--- a/app/src/main/java/dev/aurakai/auraframefx/ui/gates/HelpDeskScreen.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/ui/gates/HelpDeskScreen.kt
@@ -39,6 +39,12 @@ import androidx.compose.ui.unit.sp
  * @param onNavigateBack Callback invoked when the top app bar navigation icon is pressed.
  */
 @OptIn(ExperimentalMaterial3Api::class)
+/**
+ * Renders the Genesis Help Desk screen containing a top app bar, a list of quick-access cards,
+ * a list of popular topics, and a support statistics card.
+ *
+ * @param onNavigateBack Callback invoked when the top app bar navigation icon is pressed.
+ */
 @Composable
 fun HelpDeskScreen(
     onNavigateBack: () -> Unit = {}

--- a/app/src/main/java/dev/aurakai/auraframefx/ui/gates/LSPosedGateScreen.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/ui/gates/LSPosedGateScreen.kt
@@ -39,6 +39,15 @@ import kotlinx.coroutines.delay
  * @param onNavigateBack Callback invoked when the back navigation icon is pressed.
  */
 @OptIn(ExperimentalMaterial3Api::class)
+/**
+ * Displays the LSPosed control screen containing framework status, quick actions, and active modules.
+ *
+ * The UI shows a top app bar with back navigation, a status card for framework state and statistics,
+ * a list of quick action cards, and a list of expandable module cards. The displayed total hook
+ * count is periodically updated to simulate dynamic changes.
+ *
+ * @param onNavigateBack Called when the top app bar back button is pressed. Defaults to a no-op.
+ */
 @Composable
 fun LSPosedGateScreen(
     onNavigateBack: () -> Unit = {}
@@ -216,11 +225,11 @@ private fun StatusCard(
 }
 
 /**
- * Renders a tappable-looking card representing a quick action with its icon, title, description, and trailing chevron.
+ * Display a quick-action card showing an icon, title, description, and trailing chevron.
  *
- * The card's background color is derived from the action's `color`, and text/icon content is styled for high-contrast display.
+ * The card is populated from the provided QuickAction and styled for high-contrast readability.
  *
- * @param action The quick action data containing `title`, `description`, `icon`, and `color` used to populate the card.
+ * @param action QuickAction data used to populate the card (title, description, icon, and color).
  */
 @Composable
 private fun QuickActionCard(action: QuickAction) {
@@ -273,11 +282,11 @@ private fun QuickActionCard(action: QuickAction) {
 }
 
 /**
- * Displays a collapsible card for a module that shows its name, package, enabled state, and — when expanded — details and action buttons.
+ * Renders a collapsible card representing an Xposed module.
  *
- * When tapped the card toggles between collapsed and expanded states. In collapsed state it shows the module title, package name, and an ACTIVE/DISABLED badge. In expanded state it additionally shows Version, Hooks, Scope, and two action buttons for enabling/disabling the module and viewing logs.
+ * The collapsed card shows the module name, package name, and an ACTIVE/DISABLED badge. When expanded it also shows Version, Hooks, Scope, and action buttons to toggle enable state and view logs.
  *
- * @param module The module metadata to display (name, packageName, version, enabled, hookCount, scope).
+ * @param module Module metadata to display (name, packageName, version, enabled, hookCount, scope).
  */
 @Composable
 private fun ModuleCard(module: XposedModule) {

--- a/app/src/main/java/dev/aurakai/auraframefx/ui/screens/MainScreen.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/ui/screens/MainScreen.kt
@@ -2,6 +2,7 @@ package dev.aurakai.auraframefx.ui.screens
 
 import androidx.compose.animation.core.*
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -32,6 +33,16 @@ import kotlinx.coroutines.delay
  * - UI/UX Design Studio (theme engine, status bar customization)
  * - Help Desk (live support, docs, tutorials)
  * - Aura's Lab (experimental features)
+ */
+/**
+ * Composes the main dashboard screen for the Genesis Protocol, presenting system status and quick-access actions.
+ *
+ * Displays a top app bar with settings, a system status card with a pulsing consciousness indicator and simulated metrics,
+ * and a list of quick-access cards that trigger navigation callbacks.
+ *
+ * @param onNavigateToAgentNexus Invoked when the Agent Nexus quick-access item is selected.
+ * @param onNavigateToOracleDrive Invoked when the Oracle Drive quick-access item is selected.
+ * @param onNavigateToSettings Invoked when the Settings action in the top app bar is pressed.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -134,6 +145,14 @@ fun MainScreen(
     }
 }
 
+/**
+ * Displays a card summarizing current system status: active agents, consciousness level, and system load.
+ *
+ * @param activeAgents Number of currently active agents.
+ * @param consciousnessLevel Consciousness level as a percentage (0–100).
+ * @param systemLoad System load as a percentage (0–100).
+ * @param consciousnessAlpha Alpha value (0–1) used to render the pulsing consciousness gradient accent.
+ */
 @Composable
 private fun SystemStatusCard(
     activeAgents: Int,
@@ -183,7 +202,7 @@ private fun SystemStatusCard(
                     Text(
                         "⚡ Online",
                         style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.tertiary
+                        color = Color.Green
                     )
                 }
 
@@ -217,6 +236,14 @@ private fun SystemStatusCard(
     }
 }
 
+/**
+ * Renders a vertically stacked metric with an icon, a prominent value, and a small label.
+ *
+ * @param label The metric label shown beneath the value.
+ * @param value The metric value shown prominently above the label.
+ * @param icon The icon displayed above the value.
+ * @param color The color applied to the icon and value text.
+ */
 @Composable
 private fun StatusMetric(
     label: String,
@@ -248,11 +275,19 @@ private fun StatusMetric(
     }
 }
 
+/**
+ * Renders a clickable quick-access card displaying an icon chip, title, description, optional badge, and a trailing chevron.
+ *
+ * Tapping the card invokes the item's `onClick` handler.
+ *
+ * @param item The QuickAccessItem containing the title, description, icon, color, optional badge text, and click action to display.
+ */
 @Composable
 private fun QuickAccessCard(item: QuickAccessItem) {
     Card(
-        onClick = item.onClick,
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { item.onClick() },
         shape = RoundedCornerShape(12.dp),
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surface
@@ -325,6 +360,13 @@ private data class QuickAccessItem(
     val onClick: () -> Unit
 )
 
+/**
+ * Builds the list of quick-access items displayed in the dashboard's Quick Access section.
+ *
+ * @param onNavigateToAgentNexus Callback invoked when the "Agent Hub" item is selected.
+ * @param onNavigateToOracleDrive Callback invoked when the "Oracle Drive" item is selected.
+ * @return A list of configured QuickAccessItem instances representing navigable dashboard shortcuts.
+ */
 private fun getQuickAccessItems(
     onNavigateToAgentNexus: () -> Unit,
     onNavigateToOracleDrive: () -> Unit


### PR DESCRIPTION
📝 Add docstrings to `claude/fix-package-locations-01VYw2Y88t3ZN78Cr7LUYtyD`

## Summary by Sourcery

Document UI composables and Genesis hooks with descriptive KDoc-style comments and make small UI behavior tweaks.

New Features:
- Add descriptive KDoc comments to main dashboard, sandbox playground, LSPosed gate, and Help Desk composables and related helper functions.
- Document Genesis Xposed hook entry points for status bar indicator, Quick Settings integration, ethical governor, activity tracking, and launcher widgets.

Enhancements:
- Adjust color preview in Sandbox color swatches to use a truncated string representation instead of ARGB formatting.
- Change the system status "Online" label to use a fixed green color instead of the tertiary theme color.
- Make QuickAccessCard explicitly clickable via a Modifier instead of relying on Card's onClick parameter.