### PR TITLE
fix(di): Fix ConferenceRoomViewModel service imports

### DIFF
--- a/app/src/main/java/dev/aurakai/auraframefx/viewmodel/ConferenceRoomViewModel.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/viewmodel/ConferenceRoomViewModel.kt
@@ -4,8 +4,8 @@ package dev.aurakai.auraframefx.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dev.aurakai.auraframefx.ai.services.AuraAIService
-import dev.aurakai.auraframefx.ai.services.ClaudeAIService
+import dev.aurakai.auraframefx.oracledrive.genesis.ai.AuraAIService
+import dev.aurakai.auraframefx.oracledrive.genesis.ai.ClaudeAIService
 import dev.aurakai.auraframefx.cascade.CascadeAIService
 import dev.aurakai.auraframefx.kai.KaiAIService
 import dev.aurakai.auraframefx.models.AgentCapabilityCategory


### PR DESCRIPTION
Fixed package imports for AuraAIService and ClaudeAIService:
- ai.services.AuraAIService → oracledrive.genesis.ai.AuraAIService
- ai.services.ClaudeAIService → oracledrive.genesis.ai.ClaudeAIService

This resolves KSP error: '@HiltViewModel annotated class should contain exactly one @Inject or @AssistedInject annotated constructor'

The @Inject constructor was present but KSP couldn't resolve dependencies due to wrong package imports.

## Summary by Sourcery

Bug Fixes:
- Fix incorrect AuraAIService and ClaudeAIService imports in ConferenceRoomViewModel that prevented Hilt/KSP from resolving dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fix Dependency Injection Import Issue in ConferenceRoomViewModel

This PR resolves a Kotlin Symbol Processing (KSP) build error in the `ConferenceRoomViewModel` class by correcting the import paths for AI service dependencies.

### Changes

**File Modified:** `app/src/main/java/dev/aurakai/auraframefx/viewmodel/ConferenceRoomViewModel.kt`

**Import Corrections:**
- `import dev.aurakai.auraframefx.ai.services.AuraAIService` → `import dev.aurakai.auraframefx.oracledrive.genesis.ai.AuraAIService`
- `import dev.aurakai.auraframefx.ai.services.ClaudeAIService` → `import dev.aurakai.auraframefx.oracledrive.genesis.ai.ClaudeAIService`

### Problem Addressed

The `@HiltViewModel` annotated class was failing with the error: **"@HiltViewModel annotated class should contain exactly one @Inject or @AssistedInject annotated constructor"**

Although an `@Inject` constructor was present in the class, Kotlin Symbol Processing (KSP) could not resolve the dependency types because the service classes were being imported from incorrect package locations. This caused KSP to fail to validate the constructor injection during compilation.

### Root Cause

The services (`AuraAIService` and `ClaudeAIService`) exist in the `oracledrive.genesis.ai` package module, but the ViewModel was attempting to import them from the legacy `ai.services` package. This package mismatch prevented KSP from properly resolving dependencies during code generation for Hilt's dependency injection.

### Solution

Updated the import paths to reference the correct module location where the actual service implementations reside. This allows KSP to correctly validate that the injected dependencies exist and match the constructor parameter types.

### Impact

- **No functional changes** to the ViewModel logic or API
- **No changes** to type signatures, method behavior, or control flow
- **Build-only fix** that enables proper dependency injection validation
- Enables the application to compile successfully with Hilt's annotation processor

<!-- end of auto-generated comment: release notes by coderabbit.ai -->