### PR TITLE
fix(build): Resolve compilation errors and CMake location issues

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,7 +62,8 @@ android {
         externalNativeBuild {
             cmake {
                 path = file("src/main/cpp/CMakeLists.txt")
-                version = "3.31.5"
+                // Use CMake version that matches SDK installation
+                version = "3.22.1"
             }
         }
     }

--- a/app/src/main/java/dev/aurakai/auraframefx/aura/ui/AgentAdvancementScreen.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/aura/ui/AgentAdvancementScreen.kt
@@ -297,7 +297,7 @@ fun StatsPanel(
  * @param color Color used for the progress indicator and the percentage text.
  */
 @Composable
-fun StatBar(
+private fun StatBar(
     label: String,
     value: Float,
     color: Color

--- a/app/src/main/java/dev/aurakai/auraframefx/aura/ui/AgentNexusScreen.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/aura/ui/AgentNexusScreen.kt
@@ -406,7 +406,7 @@ fun AgentStatsPanel(
 }
 
 @Composable
-fun StatBar(
+private fun StatBar(
     label: String,
     value: Float,
     color: Color

--- a/app/src/main/java/dev/aurakai/auraframefx/aura/ui/HomeScreen.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/aura/ui/HomeScreen.kt
@@ -38,9 +38,9 @@ import androidx.compose.ui.unit.sp
 import dev.aurakai.auraframefx.R
 import dev.aurakai.auraframefx.aura.animations.cyberEdgeGlow
 import dev.aurakai.auraframefx.aura.animations.digitalPixelEffect
+import dev.aurakai.auraframefx.aura.ui.CyberMenuItem
 import dev.aurakai.auraframefx.ui.components.BackgroundStyle
 import dev.aurakai.auraframefx.ui.components.CornerStyle
-import dev.aurakai.auraframefx.ui.components.CyberMenuItem
 import dev.aurakai.auraframefx.ui.components.CyberpunkText
 import dev.aurakai.auraframefx.ui.components.DigitalLandscapeBackground
 import dev.aurakai.auraframefx.ui.components.FloatingCyberWindow
@@ -50,12 +50,7 @@ import dev.aurakai.auraframefx.ui.components.cyberEdgeGlow
 import dev.aurakai.auraframefx.ui.components.digitalGlitchEffect
 import dev.aurakai.auraframefx.ui.gates.GateCard
 import dev.aurakai.auraframefx.ui.gates.GateConfigs
-import dev.aurakai.auraframefx.ui.theme.CyberpunkTextColor
-import dev.aurakai.auraframefx.ui.theme.CyberpunkTextStyle
-import dev.aurakai.auraframefx.ui.theme.NeonBlue
-import dev.aurakai.auraframefx.ui.theme.NeonCyan
-import dev.aurakai.auraframefx.ui.theme.NeonGreen
-import dev.aurakai.auraframefx.ui.theme.NeonPink
+import dev.aurakai.auraframefx.ui.*
 import kotlinx.coroutines.launch
 
 

--- a/app/src/main/java/dev/aurakai/auraframefx/ui/theme/CyberpunkTextColor.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/ui/theme/CyberpunkTextColor.kt
@@ -1,0 +1,17 @@
+package dev.aurakai.auraframefx.ui.theme
+
+import androidx.compose.ui.graphics.Color
+import dev.aurakai.auraframefx.ui.*
+
+/**
+ * Cyberpunk text color scheme for themed text components.
+ */
+enum class CyberpunkTextColor(val color: Color) {
+    Primary(CyberpunkCyan),
+    Secondary(CyberpunkPink),
+    Tertiary(CyberpunkPurple),
+    White(Color.White),
+    Warning(NeonYellow),
+    Error(NeonRed),
+    Success(NeonGreen)
+}

--- a/app/src/main/java/dev/aurakai/auraframefx/ui/theme/CyberpunkTextStyle.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/ui/theme/CyberpunkTextStyle.kt
@@ -1,0 +1,16 @@
+package dev.aurakai.auraframefx.ui.theme
+
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+
+/**
+ * Cyberpunk text styles for themed text components.
+ */
+enum class CyberpunkTextStyle(val textStyle: TextStyle) {
+    Title(TextStyle(fontSize = 24.sp, fontWeight = FontWeight.Bold, letterSpacing = 1.sp)),
+    Heading(TextStyle(fontSize = 20.sp, fontWeight = FontWeight.Bold, letterSpacing = 0.75.sp)),
+    Body(TextStyle(fontSize = 16.sp, fontWeight = FontWeight.Normal, letterSpacing = 0.5.sp)),
+    Label(TextStyle(fontSize = 14.sp, fontWeight = FontWeight.Medium, letterSpacing = 0.5.sp)),
+    Caption(TextStyle(fontSize = 12.sp, fontWeight = FontWeight.Normal, letterSpacing = 0.25.sp))
+}


### PR DESCRIPTION
Fixed multiple compilation errors that were preventing the build:

**Duplicate Function Definitions:**
- Made StatBar functions private in AgentNexusScreen.kt and AgentAdvancementScreen.kt
- This resolves the "Conflicting overloads" error for the StatBar function

**Missing Theme Classes:**
- Created CyberpunkTextColor.kt with color enum for themed text components
- Created CyberpunkTextStyle.kt with text style enum for typography
- These classes are required by CyberpunkText component

**Import Fixes:**
- Fixed HomeScreen.kt to import CyberMenuItem from correct package (aura.ui instead of ui.components)
- Updated color imports to use dev.aurakai.auraframefx.ui.* package

**CMake Configuration:**
- Changed CMake version from 3.31.5 to 3.22.1 in app/build.gradle.kts
- This matches the minimum CMake version in CMakeLists.txt and avoids location mismatch warnings
- Resolves [CXX5304] warnings about inconsistent CMake package locations

All changes maintain backward compatibility while fixing critical build blockers.

## Summary by Sourcery

Fix build and theme-related compilation issues across UI modules and native configuration.

New Features:
- Introduce CyberpunkTextColor enum defining the color palette for cyberpunk-themed text components.
- Introduce CyberpunkTextStyle enum encapsulating common typography styles for cyberpunk-themed text.

Bug Fixes:
- Resolve conflicting StatBar composable definitions by scoping them privately in Agent advancement and nexus screens.
- Correct HomeScreen imports to use the CyberMenuItem from the aura.ui package and consolidate theme/color imports.
- Align Gradle CMake configuration with the installed SDK version to eliminate CMake version mismatch warnings.

Build:
- Update CMake version in app Gradle configuration to 3.22.1 to match the native build toolchain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Build System and Theme Configuration Fixes

This PR resolves critical compilation errors and CMake configuration issues across the Android build system and UI layer.

### CMake Configuration Update
- Updated CMake version in `app/build.gradle.kts` from 3.31.5 to 3.22.1 to align with the minimum version specified in CMakeLists.txt, eliminating CMake location mismatch warnings and resolving [CXX5304] inconsistent CMake package location errors.

### Duplicate Function Resolution
- Made `StatBar` function private in `AgentNexusScreen.kt` to resolve "Conflicting overloads" compilation errors caused by duplicate function definitions.
- Made `StatBar` function private in `AgentAdvancementScreen.kt` for the same reason, maintaining internal usage while preventing export scope conflicts.

### Missing Theme Classes Implementation
- Added `CyberpunkTextColor.kt`: New public enum providing themed text color constants (Primary, Secondary, Tertiary, White, Warning, Error, Success) mapped to existing cyberpunk color values and standard colors.
- Added `CyberpunkTextStyle.kt`: New public enum defining typography presets (Title, Heading, Body, Label, Caption) with specific fontSize, fontWeight, and letterSpacing configurations for consistent theming.

### Import Corrections
- Updated `HomeScreen.kt` imports to correctly reference `CyberMenuItem` from `dev.aurakai.auraframefx.aura.ui` package.
- Replaced individual theme imports with wildcard import `dev.aurakai.auraframefx.ui.*` for cleaner dependency management.

All changes maintain backward compatibility while addressing critical build blockers that prevented successful compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->